### PR TITLE
Fix building for 32-bit targets

### DIFF
--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -39,17 +39,10 @@ pub fn color2egui(color: Color) -> egui::Color32 {
     // egui::Color32::from(egui::Rgba::from_rgba_premultiplied(c.r, c.g, c.b, c.a))
 }
 
-/// Converts an u64, stored in an `egui::Texture::User` back into a Godot `Rid`.
-#[allow(dead_code)]
-fn u64_to_rid(x: u64) -> Rid {
-    // Safety: Godot Rids should always fit in an u64, so it's safe to transmute
-    unsafe { Rid::from_sys(std::mem::transmute::<u64, gdnative::sys::godot_rid>(x)) }
-}
-
 /// Converts a godot `Rid` into an `egui::TextureId`
 pub fn rid_to_egui_texture_id(x: Rid) -> egui::TextureId {
-    // Safety: See `u64_to_rid`
-    unsafe { egui::TextureId::User(std::mem::transmute::<gdnative::sys::godot_rid, u64>(*x.sys())) }
+    // Safety: see `Rid::to_u64`
+    unsafe { egui::TextureId::User(std::mem::transmute::<gdnative::sys::godot_rid, usize>(*x.sys()) as u64) }
 }
 #[derive(ToVariant)]
 enum GodotEguiInputMode {


### PR DESCRIPTION
I am trying to get my project working as WASM export, but building fails with

```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
  --> /home/k/.cargo/git/checkouts/godot-egui-296d05925de6df69/6271b59/godot_egui/src/lib.rs:52:36
   |
52 |     unsafe { egui::TextureId::User(std::mem::transmute::<gdnative::sys::godot_rid, u64>(*x.sys())) }
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: source type: `godot_rid` (32 bits)
   = note: target type: `u64` (64 bits)
```
as WASM is a 32-bit target. The fix is copied from the (private) function [`Rid::to_u64`](https://docs.rs/gdnative-core/latest/src/gdnative_core/core_types/rid.rs.html#59). I have removed `u64_to_rid` because it was unused and seems dangerous. See [this](https://docs.rs/gdnative-core/0.10.0/gdnative_core/core_types/struct.Rid.html):

>Note that RIDs are highly unsafe to work with (especially with a Release build of Godot):
>- The internal handle is interpreted as a raw pointer by Godot, meaning that passing an invalid or wrongly typed RID is instant undefined behavior.
>
>For this reason, GDNative methods accepting Rid parameters are marked unsafe.

That last line means it is *technically* not unsafe to turn a u64 into a `Rid` (because the transmuting on its own can't really fail), but it still seems unwise. If you still want to keep that function, it should at least be `usize_to_rid` instead.